### PR TITLE
only julia >= 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
-          - '1.4'
-          - '1.5'
           - '1.6'
           - '~1.7.0-0'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
 Scratch = "1.1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
we don't need other versions anymore for singular / polymake and it simplifies testing.
(The package would probably still work for >=1.3)