### PR TITLE
don't use symlinks for wrappers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryWrappers"
 uuid = "f01c122e-0ea1-4f85-ad8f-907073ad7a9f"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"


### PR DESCRIPTION
Singular does not like symlinks for 4ti2, it will call readlink and try to use the wrapper directly and thus $0 will not contain the target name anymore
so we just copy the wrapper for each original binary/script

also try to use the same shell as the original script
and only support POSIX scripts