### PR TITLE
Allow `@generate_wrappers(Pkg.SubPkg)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryWrappers"
 uuid = "f01c122e-0ea1-4f85-ad8f-907073ad7a9f"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"

--- a/src/BinaryWrappers.jl
+++ b/src/BinaryWrappers.jl
@@ -66,7 +66,7 @@ end
 # this behaves slightly different than the @get_scratch! function:
 # it will associate the scratch to the module passed as argument
 # and use the calling module for the scratch usage (for gc)
-macro generate_wrappers(m::Symbol)
+macro generate_wrappers(m::Union{Symbol,Expr})
     uuid = Base.PkgId(__module__).uuid
     return quote
         generate_wrappers($(esc(m)), $(esc(uuid)))


### PR DESCRIPTION
Instead of having to write

    import Pkg.SubPkg
    BinaryWrappers.@generate_wrappers(SubPkg)

with this patch one can simply write

    BinaryWrappers.@generate_wrappers(Pkg.SubPkg)
