### PR TITLE
Add support for perl scripts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,21 +14,19 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
           - '1.10'
-          - '~1.11.0-0'
+          - '1.11'
+          - '1.12'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryWrappers"
 uuid = "f01c122e-0ea1-4f85-ad8f-907073ad7a9f"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de> and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryWrappers"
 uuid = "f01c122e-0ea1-4f85-ad8f-907073ad7a9f"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de> and contributors"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"

--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,17 @@ version = "0.1.3"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
+[weakdeps]
+Perl_jll = "83958c19-0796-5285-893e-a1267f8ec499"
+
+[extensions]
+Perl_jllExt = "Perl_jll"
+
 [compat]
 JLLWrappers = "1.2"
+Perl_jll = "5.34.1"
 Scratch = "1.1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/ext/Perl_jllExt.jl
+++ b/ext/Perl_jllExt.jl
@@ -1,10 +1,18 @@
 module Perl_jllExt
 
 import BinaryWrappers
+import JLLWrappers
 import Perl_jll
 
 function BinaryWrappers.perl_script_wrapper_contents(libpath::String, sourcebinary::String)
-    return "test"
+    perlbinary = Perl_jll.get_perl_path()
+    return """
+        #!/bin/sh
+        # Since we cannot run these binaries through the usual julia commands we need
+        # this wrapper that sets up the correct library paths.
+        export $(JLLWrappers.LIBPATH_env)="$(libpath)"
+        exec $(perlbinary) -- $(sourcebinary) "\$@"
+        """
 end
 
 end # module Perl_jllExt

--- a/ext/Perl_jllExt.jl
+++ b/ext/Perl_jllExt.jl
@@ -1,0 +1,10 @@
+module Perl_jllExt
+
+import BinaryWrappers
+import Perl_jll
+
+function BinaryWrappers.perl_script_wrapper_contents(libpath::String, sourcebinary::String)
+    return "test"
+end
+
+end # module Perl_jllExt

--- a/src/BinaryWrappers.jl
+++ b/src/BinaryWrappers.jl
@@ -22,8 +22,9 @@ function shell_script_wrapper_contents(libpath::String, sourcebinary::String)
     # the LIBPATH. This means \$0 will point to our wrapper.
     # For 4ti2 this means that its own wrapper scripts will call our wrapper for the
     # binaries, so strictly speaking adjusting the LIBPATH here is not necessary.
+
+    # The shebang line needs to be added by the caller.
     return """
-        #!/bin/sh
         # We cannot run shell scripts directly as macOS will remove
         # DYLD_FALLBACK_LIBRARY_PATH for any subshells.
         # So we source the original script instead.
@@ -64,9 +65,9 @@ function generate_wrappers(m::Module, caller::Union{Module, Base.UUID, Nothing})
             # because it might be a binary without any linebreaks
             # longest relevant start: length("#!/usr/bin/env perl") == 19
             shebang = String(read(joinpath(bindir, bin), 19))
-            if match(shellre, shebang) !== nothing
+            if (m = match(shellre, shebang); m !== nothing)
                 # shell scripts use a different wrapper because macOS...
-                write(tmpio, shell_script_wrapper_contents(libpath, sourcebinary))
+                write(tmpio, m.match * "\n" * shell_script_wrapper_contents(libpath, sourcebinary))
             elseif match(perlre, shebang) !== nothing
                 write(tmpio, perl_script_wrapper_contents(libpath, sourcebinary))
             else

--- a/src/BinaryWrappers.jl
+++ b/src/BinaryWrappers.jl
@@ -60,7 +60,10 @@ function generate_wrappers(m::Module, caller::Union{Module, Base.UUID, Nothing})
     for bin in readdir(bindir)
         if isfile(joinpath(bindir, bin))
             (tmpfile, tmpio) = mktemp(binpath(""); cleanup=false)
-            shebang = readline(joinpath(bindir, bin))
+            # we don't want to use readline here
+            # because it might be a binary without any linebreaks
+            # longest relevant start: length("#!/usr/bin/env perl") == 19
+            shebang = String(read(joinpath(bindir, bin), 19))
             if match(shellre, shebang) !== nothing
                 # shell scripts use a different wrapper because macOS...
                 write(tmpio, shell_script_wrapper_contents(libpath, sourcebinary))

--- a/src/BinaryWrappers.jl
+++ b/src/BinaryWrappers.jl
@@ -31,6 +31,11 @@ function shell_script_wrapper_contents(libpath::String, sourcebinary::String)
         """
 end
 
+# defined in Perl_jllExt
+function perl_script_wrapper_contents(_, _)
+    error("`perl_script_wrapper_contents` needs `Perl_jll` to be loaded.")
+end
+
 # use @generate_wrappers instead to automatically deduce the calling module
 function generate_wrappers(m::Module, caller::Union{Module, Base.UUID, Nothing})
     # we generate wrappers per minor julia version

--- a/src/BinaryWrappers.jl
+++ b/src/BinaryWrappers.jl
@@ -23,6 +23,7 @@ function shell_script_wrapper_contents(libpath::String, sourcebinary::String)
     # For 4ti2 this means that its own wrapper scripts will call our wrapper for the
     # binaries, so strictly speaking adjusting the LIBPATH here is not necessary.
     return """
+        #!/bin/sh
         # We cannot run shell scripts directly as macOS will remove
         # DYLD_FALLBACK_LIBRARY_PATH for any subshells.
         # So we source the original script instead.
@@ -53,13 +54,18 @@ function generate_wrappers(m::Module, caller::Union{Module, Base.UUID, Nothing})
     # POSIX compatible shells
     shellre = r"^#!/bin/(ba|da|z|k)?sh"
 
+    # Perl scripts
+    perlre = r"^#!/usr/bin/(perl|env perl)"
+
     for bin in readdir(bindir)
         if isfile(joinpath(bindir, bin))
             (tmpfile, tmpio) = mktemp(binpath(""); cleanup=false)
             shebang = readline(joinpath(bindir, bin))
             if match(shellre, shebang) !== nothing
                 # shell scripts use a different wrapper because macOS...
-                write(tmpio, "#!/bin/sh\n" * shell_script_wrapper_contents(libpath, sourcebinary))
+                write(tmpio, shell_script_wrapper_contents(libpath, sourcebinary))
+            elseif match(perlre, shebang) !== nothing
+                write(tmpio, perl_script_wrapper_contents(libpath, sourcebinary))
             else
                 write(tmpio, wrapper_contents(libpath, sourcebinary))
             end

--- a/src/BinaryWrappers.jl
+++ b/src/BinaryWrappers.jl
@@ -7,52 +7,56 @@ using JLLWrappers
 
 const wrapper_key = "binarywrappers_v$(VERSION.major).$(VERSION.minor)"
 
-# use @generate_wrappers instead to automatically deduce the calling module
-function generate_wrappers(m::Module, caller::Union{Module, Base.UUID, Nothing})
-    # we generate wrappers per minor julia version
-    # the scratch will belong to the jll which the wrappers are generated for
-    # and the usage is tied to the module calling the `@generate` macro.
-    target = get_scratch!(m, wrapper_key, caller)
-     
-    binpath(name) = joinpath(target, "bin", name)
-    mkpath(binpath(""))
-
-    bindir = joinpath(getproperty(m, :artifact_dir), "bin")
-    sourcebinary = joinpath(bindir,"\$(basename \$0)")
-    libpath = getproperty(m, :LIBPATH)[]
-
-    wrapper = """
+function wrapper_contents(libpath::String, sourcebinary::String)
+    return """
         #!/bin/sh
         # Since we cannot run these binaries through the usual julia commands we need
         # this wrapper that sets up the correct library paths.
         export $(JLLWrappers.LIBPATH_env)="$(libpath)"
         exec $(sourcebinary) "\$@"
         """
+end
 
+function shell_script_wrapper_contents(libpath::String, sourcebinary::String)
     # For shell scripts we use `source` (.) instead of exec to avoid macOS stripping
     # the LIBPATH. This means \$0 will point to our wrapper.
     # For 4ti2 this means that its own wrapper scripts will call our wrapper for the
     # binaries, so strictly speaking adjusting the LIBPATH here is not necessary.
-    scriptwrapper = """
+    return """
         # We cannot run shell scripts directly as macOS will remove
         # DYLD_FALLBACK_LIBRARY_PATH for any subshells.
         # So we source the original script instead.
         export $(JLLWrappers.LIBPATH_env)="$(libpath)"
         . $(sourcebinary) "\$@"
         """
+end
+
+# use @generate_wrappers instead to automatically deduce the calling module
+function generate_wrappers(m::Module, caller::Union{Module, Base.UUID, Nothing})
+    # we generate wrappers per minor julia version
+    # the scratch will belong to the jll which the wrappers are generated for
+    # and the usage is tied to the module calling the `@generate` macro.
+    target = get_scratch!(m, wrapper_key, caller)
+
+    binpath(name) = joinpath(target, "bin", name)
+    mkpath(binpath(""))
+
+    bindir = joinpath(getproperty(m, :artifact_dir), "bin")
+    sourcebinary = joinpath(bindir, "\$(basename \$0)")
+    libpath = getproperty(m, :LIBPATH)[]
 
     # POSIX compatible shells
     shellre = r"^#!/bin/(ba|da|z|k)?sh"
 
     for bin in readdir(bindir)
         if isfile(joinpath(bindir, bin))
-            (tmpfile, tmpio) = mktemp(binpath(""),cleanup=false)
-            # shell scripts use a different wrapper because macOS...
-            m = match(shellre, String(read(joinpath(bindir, bin), 11)))
-            if m != nothing
-                write(tmpio, m.match * "\n" * scriptwrapper)
+            (tmpfile, tmpio) = mktemp(binpath(""); cleanup=false)
+            shebang = readline(joinpath(bindir, bin))
+            if match(shellre, shebang) !== nothing
+                # shell scripts use a different wrapper because macOS...
+                write(tmpio, "#!/bin/sh\n" * shell_script_wrapper_contents(libpath, sourcebinary))
             else
-                write(tmpio, wrapper)
+                write(tmpio, wrapper_contents(libpath, sourcebinary))
             end
             close(tmpio)
             chmod(tmpfile, 0o755)


### PR DESCRIPTION
This moves the code by @fingolfin from https://github.com/oscar-system/GAP.jl/pull/1296 upstream to the IMO more suitable place (x-ref https://github.com/oscar-system/GAP.jl/issues/1122#issuecomment-2586815929).
To not have to add Perl_jll as a dependency here, I instead added a package extension handling Perl scripts (which needs a bump of the julia compat).

The corresponding change in GAP.jl is https://github.com/oscar-system/GAP.jl/pull/1310.